### PR TITLE
preallocate patch_q_indices

### DIFF
--- a/src/WNNMDenoise.jl
+++ b/src/WNNMDenoise.jl
@@ -270,7 +270,7 @@ function WNNM_optimizer!(out, Y, σₚ; C, fixed_point_num_iters=3)
     #       applications; it simply isn't designed so.
 
     n = size(Y, 2)
-    U, ΣY, V = svd!(Y)
+    F = svd!(Y)
 
     # For image denoising problems, it is natural to shrink large singular value less, i.e., to set
     # smaller weight to large singular value. For this reason, it uses `w = (C * sqrt(n))/(ΣX + eps())`
@@ -278,21 +278,21 @@ function WNNM_optimizer!(out, Y, σₚ; C, fixed_point_num_iters=3)
     # condition for Corollary 1 holds, and thus we could directly get the desired solution in a single
     # step.
 
-    # Here we iterate more than once because we don't know what ΣX is; we have to iterate it a while 
+    # Here we iterate more than once because we don't know what ΣX is; we have to iterate it a while
     # from ΣY to get an relatively good estimation of it.
     # TODO: could we set default σₚ as 0?
     # TODO: is this the best initialization we can get?
-    ΣX = @. sqrt(max(ΣY^2 - n * σₚ^2, 0))
+    ΣX = @. sqrt(max(F.S^2 - n * σₚ^2, 0))
     for _ in 1:fixed_point_num_iters
         # the iterative algorithm proposed in section 2.2.2 in [1]
         # Step 1 in the iterative algorithm becomes trivial and a no-op
 
         # Step 2 degenerates to a soft thresholding; both P and Q are identity matrix.
         # all in one line to avoid unnecessary allocation for temporarily variable w
-        @. ΣX = soft_threshold(ΣY, (C * sqrt(n) * σₚ^2) / (ΣX + eps()))
+        @. ΣX = soft_threshold(F.S, (C * sqrt(n) * σₚ^2) / (ΣX + eps()))
     end
 
-    mul!(out, rmul!(U, Diagonal(ΣX)), V')
+    mul!(out, rmul!(F.U, Diagonal(ΣX)), F.Vt)
 end
 
 

--- a/src/WNNMDenoise.jl
+++ b/src/WNNMDenoise.jl
@@ -282,14 +282,18 @@ function WNNM_optimizer!(out, Y, σₚ; C, fixed_point_num_iters=3)
     # from ΣY to get an relatively good estimation of it.
     # TODO: could we set default σₚ as 0?
     # TODO: is this the best initialization we can get?
-    ΣX = @. sqrt(max(F.S^2 - n * σₚ^2, 0))
+    σₚ² = σₚ*σₚ
+    nσₚ² = n*σₚ²
+    Csnσₚ² = C * sqrt(n) * σₚ²
+
+    ΣX = @. sqrt(max(F.S*F.S - nσₚ², zero(σₚ)))
     for _ in 1:fixed_point_num_iters
         # the iterative algorithm proposed in section 2.2.2 in [1]
         # Step 1 in the iterative algorithm becomes trivial and a no-op
 
         # Step 2 degenerates to a soft thresholding; both P and Q are identity matrix.
         # all in one line to avoid unnecessary allocation for temporarily variable w
-        @. ΣX = soft_threshold(F.S, (C * sqrt(n) * σₚ^2) / (ΣX + eps()))
+        @. ΣX = soft_threshold(F.S, Csnσₚ² / (ΣX + eps()))
     end
 
     mul!(out, rmul!(F.U, Diagonal(ΣX)), F.Vt)


### PR DESCRIPTION
- Less GC time
- More allocations (need to check)

```julia
img = Float32.(load("house.png")) * 255;
σₙ = 40
noisy_img = matopen("house_AWGN_$(σₙ).mat") do io
    read(io, "N_Img")
end
out = copy(noisy_img)
f = WNNM(σₙ)

@time f(out, noisy_img);
# before: 26.515717 seconds (23.49 M allocations: 43.156 GiB, 32.50% gc time)
# after: 22.892699 seconds (115.39 M allocations: 29.770 GiB, 22.67% gc time)
```