### PR TITLE
fix runtime dispatch

### DIFF
--- a/src/WNNMDenoise.jl
+++ b/src/WNNMDenoise.jl
@@ -242,7 +242,7 @@ function _estimate_patch!(patch_q_indices, out, patch_group,
     alg = FullSearch{Cityblock, 2}(
         Cityblock(),
         rₚ,
-        CartesianIndex(window_size, window_size),
+        CartesianIndex(window_size÷2, window_size÷2),
         CartesianIndex(1, 1)
     )
     q_inds = multi_match(alg, imgₑₛₜ, imgₑₛₜ, p; num_patches=num_patches)


### PR DESCRIPTION
Using JETTest to identify some runtime dispatches and fix the type instability:

```julia
img = Float32.(load("house.png")) * 255;
σₙ = 40
noisy_img = matopen("house_AWGN_$(σₙ).mat") do io
    read(io, "N_Img")
end
out = copy(noisy_img)
f = WNNM(σₙ)
@time f(out, noisy_img);

# before: 20.164879 seconds (112.17 M allocations: 29.615 GiB, 17.67% gc time)
# after: 20.525119 seconds (8.90 M allocations: 26.259 GiB, 18.85% gc time)
```
