### PR TITLE
More buffer and performance tricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,15 @@ purpose.
 
 ## Noteworthy difference from the original implementation
 
+
+Performance tricks:
+
 - The block matching stride is set in both dimension, while in the original implementation [2] this
   is only set in one dimension, with the other dimension stride being 1. This extra computation
   brings almost no benefit speaking of the PSNR/runtime. For example, when noise level is `40` and
-  with the same default parameters, the overall PSNR is `31.30` in about `50` seconds, if we set
-  stride in both dimension, then PNSR is `31.29` in about `26` seconds.
+  with the same default parameters, the overall PSNR is `31.30` in about 50 seconds, if we set
+  stride in both dimension, then PNSR is `31.29` in about 26 seconds.
+- When doing block matching, we sample the patch into a smaller one by setting indexing stride `2`.
 
 
 ## References

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -53,12 +53,14 @@ function multi_match(S::FullSearch, ref, frame, p::CartesianIndex, dist_buffer; 
     q_stop = min(last(R_ref), p + S.search_radius)
     candidates = q_start:S.search_stride:q_stop
 
-    patch_p = frame[p - rₚ:p + rₚ]
+    # For performance, we do not need to compare the dense patch to do block matching
+    Δ = CartesianIndex(2, 2)
+    patch_p = frame[p - rₚ:Δ:p + rₚ]
     @assert length(dist_buffer) >= length(candidates)
     dist = dist_buffer
     @inbounds for i in 1:length(candidates)
         q = candidates[i]
-        patch_q = @view ref[q - rₚ:q + rₚ]
+        patch_q = @view ref[q - rₚ:Δ:q + rₚ]
         dist[i] = S.f(patch_p, patch_q)
     end
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -26,6 +26,19 @@ soft_threshold(x::T, γ::Number) where T <: Number = sign(x) * max(abs(x) - _may
 _maybe_promote(::Type{T}, x) where T = convert(T, x)
 _maybe_promote(::Type{T1}, x::T2) where {T1 <: Union{Bool,Integer},T2} = promote_type(T1, T2)(x)
 
+# optimized for memory
+function mean2!(out::AbstractVector, m::AbstractMatrix)
+    @assert length(out) == size(m, 1)
+    fill!(out, zero(eltype(out)))
+    @inbounds for i in axes(m, 1)
+        rst = out[i]
+        @simd for j in axes(m, 2)
+            rst += m[i, j]
+        end
+        out[i] = rst / size(m, 2)
+    end
+    return out
+end
 # Threads helper
 
 function with_blas_threads(f, num_threads)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -39,6 +39,33 @@ function mean2!(out::AbstractVector, m::AbstractMatrix)
     end
     return out
 end
+
+# Copy from BlockMatching with extra `dist_buffer` input to reuse the memory
+function multi_match(S::FullSearch, ref, frame, p::CartesianIndex, dist_buffer; num_patches)
+    rₚ = S.patch_radius
+    R_frame = CartesianIndices(frame)
+    R_frame = first(R_frame) + rₚ : last(R_frame) - rₚ
+    p in R_frame || throw(ArgumentError("Boundary unsupported now: pixel `p = $p` should be within $(first(R_frame)):$(last(R_frame))."))
+
+    R_ref = CartesianIndices(ref)
+    R_ref = first(R_ref) + rₚ : last(R_ref) - rₚ
+    q_start = max(first(R_ref), p - S.search_radius)
+    q_stop = min(last(R_ref), p + S.search_radius)
+    candidates = q_start:S.search_stride:q_stop
+
+    patch_p = frame[p - rₚ:p + rₚ]
+    @assert length(dist_buffer) >= length(candidates)
+    dist = dist_buffer
+    @inbounds for i in 1:length(candidates)
+        q = candidates[i]
+        patch_q = @view ref[q - rₚ:q + rₚ]
+        dist[i] = S.f(patch_p, patch_q)
+    end
+
+    indices = partialsortperm(view(dist, 1:length(candidates)), 1:num_patches)
+    candidates[indices]
+end
+
 # Threads helper
 
 function with_blas_threads(f, num_threads)


### PR DESCRIPTION
```julia
img = Float32.(load("house.png")) * 255;
σₙ = 40
noisy_img = matopen("house_AWGN_$(σₙ).mat") do io
    read(io, "N_Img")
end
out = copy(noisy_img)
f = WNNM(σₙ)
@time f(out, noisy_img);
# before: 21.637158 seconds (7.80 M allocations: 26.208 GiB, 24.55% gc time)
# after: 17.232886 seconds (5.03 M allocations: 21.354 GiB, 19.88% gc time)

assess_psnr(out, noisy_img, 255)
# before: 31.192419062230776
# after: 31.34762509898153
```